### PR TITLE
change metrics port to 9400 to match other zenreach services

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM confluentinc/cp-kafka-connect:4.0.0
 LABEL maintainer="Zenreach Engineering <engineering@zenreach.com>"
 
-ENV EXTRA_ARGS="-javaagent:/usr/local/share/jars/jmx_prometheus_javaagent-0.10.jar=9242:/etc/jmx_exporter/jmx_exporter.yaml "
+ENV EXTRA_ARGS="-javaagent:/usr/local/share/jars/jmx_prometheus_javaagent-0.10.jar=9400:/etc/jmx_exporter/jmx_exporter.yaml "
 
 ENV CONNECT_REST_PORT="80"
 ENV CONNECT_PLUGIN_PATH="/usr/local/share/kafka_connect/plugins"
@@ -10,7 +10,7 @@ ENV CONNECT_VALUE_CONVERTER="io.confluent.connect.avro.AvroConverter"
 ENV CONNECT_INTERNAL_KEY_CONVERTER="org.apache.kafka.connect.json.JsonConverter"
 ENV CONNECT_INTERNAL_VALUE_CONVERTER="org.apache.kafka.connect.json.JsonConverter"
 
-EXPOSE 9242
+EXPOSE 9400
 EXPOSE 80
 
 RUN mkdir -p /etc/jmx_exporter

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ KAFKA_JMX_OPTS="-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.au
 
 ## Prometheus Monitoring
 
-Prometheus metrics will be exported on port 9242. The jmx metrics that are exported are those that match the patterns in the `jmx_exporter.yaml` config.
+Prometheus metrics will be exported on port 9400. The jmx metrics that are exported are those that match the patterns in the `jmx_exporter.yaml` config.
 
 ## Example
 

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     container_name: kafka-connect
     ports:
       - "8083:80"
-      - "9242:9242"
+      - "9400:9400"
     links:
       - kafka
       - mongo
@@ -29,15 +29,16 @@ services:
     image: confluentinc/cp-schema-registry:4.0.0
     container_name: schema-registry
     links:
-      - zookeeper
+      - kafka
     ports:
-      - "8081:8081"
+      - "8081:80"
     environment:
-      - SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL=zookeeper:2181
+      - SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS=PLAINTEXT://kafka:9092
       - SCHEMA_REGISTRY_HOST_NAME=schema-registry
-      - SCHEMA_REGISTRY_LISTENERS=http://0.0.0.0:8081
+      - SCHEMA_REGISTRY_LISTENERS=http://0.0.0.0:80
       - SCHEMA_REGISTRY_DEBUG=true
       - SCHEMA_REGISTRY_KAFKASTORE_REPLICATION_FACTOR=1
+      - SCHEMA_REGISTRY_ACCESS_CONTROL_ALLOW_ORIGIN=*
 
   kafka:
     image: confluentinc/cp-kafka:4.0.0

--- a/test/test.sh
+++ b/test/test.sh
@@ -9,5 +9,5 @@ while [ "$?" != "0" ]; do
 done
 curl -XPUT "http://localhost:8083/connectors/platform-people-source/config" -H "Content-Type: application/json" -H "Accept: application/json" --data-binary @source-config.json || exit 1
 curl -XPUT "http://localhost:8083/connectors/platform-people-sink/config" -H "Content-Type: application/json" -H "Accept: application/json" --data-binary @sink-config.json || exit 1
-curl -s "http://localhost:9242/metrics" | promtool check metrics || exit 1
+curl -s "http://localhost:9400/metrics" | promtool check metrics || exit 1
 docker-compose down


### PR DESCRIPTION
This was using 9242 for metrics, which is against our convention. This PR changes metrics to be exported on 9400 which matches our internal service configs.